### PR TITLE
Adds clarification that code is exported, and example screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Director Cast Ripper
-Director Cast Ripper exports assets and information from Macromedia / Adobe Director files, including standard and compressed (Shockwave) movies and casts. It features both a friendly graphical interface and a command-line interface. Created with Director itself, its functionality is implemented using a variety of built-in functions and third-party Xtras.
+Director Cast Ripper exports code, assets, and information from Macromedia / Adobe Director files, including standard and compressed (Shockwave) movies and casts. It features both a friendly graphical interface and a command-line interface. Created with Director itself, its functionality is implemented using a variety of built-in functions and third-party Xtras.
 
 ## Download
 [Download Director Cast Ripper from the Releases page](https://github.com/n0samu/DirectorCastRipper/releases/latest).
@@ -11,6 +11,7 @@ The following table lists member types that Director Cast Ripper can export, alo
 
 | Member Types        | File formats   |
 | ------------------- | -------------- |
+| Lingo code          | LS             |
 | Bitmap, Picture     | PNG, BMP       |
 | Sound               | WAV            |
 | Flash, Vector shape | SWF            |
@@ -22,6 +23,12 @@ The following table lists member types that Director Cast Ripper can export, alo
 Director Cast Ripper exports information about movies and cast members into CSV spreadsheets. When adding and removing files, it allows multiselection of files using Shift-click or Ctrl-click. Files can also be added by dragging them into the window. All of its functionality is also accessible via the command line; run `DirectorCastRipper.exe --help` for details. Director Cast Ripper can also integrate with [ProjectorRays](https://github.com/ProjectorRays/ProjectorRays); just download the EXE file and place it in Cast Ripper's `Tools` folder.
 
 Although Cast Ripper runs within the Director Player, it disables scripting for all loaded movies, preventing their code from interfering with the export process. But the Director Player still attempts to load any cast files, linked cast members, and Xtras that each movie depends on. Therefore when exporting it is best to keep movies in their original folders and to copy any required Xtras into Cast Ripper's Xtras folder, otherwise error dialogs may pop up during the export process. If you are using Cast Ripper to process many files and don't know what Xtras they may need, Cast Ripper provides an option to auto-dismiss the error dialogs, preventing the export process from stalling.
+
+## Screenshots
+
+| Options | In progress |
+| ------- | ----------- |
+| ![options](https://github.com/n0samu/DirectorCastRipper/assets/12380876/40e35490-13ea-444f-be6f-d0b21977efea) | ![inprogress](https://github.com/n0samu/DirectorCastRipper/assets/12380876/1535ffc0-8163-422c-932b-7abb70b1a37a) |
 
 ## Credits
 Director Cast Ripper uses several third-party Xtras which are listed below.


### PR DESCRIPTION
Exporting the included code is a key feature, but it's not currently mentioned! 

Additionally, some example screenshots help it feel more "real", and not just a random `.exe` 🙂 

You might want to pick better screenshots with more advanced functionality, I just used ones I had already.